### PR TITLE
feat: add support for .coverignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ cat files | gocovdedup - > cover.out
 gocovdedup package_one.out package_tow.out commontests.out > cover.out
 ```
 
+### Ignoring packages and files
+
+Files and packages can be excluded by including a `.coverognore` file
+in the working directory.  This file works very similarly to `.gitignore` files.
+
+github.com/repo/alternate/*
+Causes te filter to remove all files immediately under `github.com/repo/alternate`
+
+\*\*/proto/\*\* 
+Excludes all packages with proto in their path.
+

--- a/filter.go
+++ b/filter.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/denormal/go-gitignore"
+	"golang.org/x/tools/cover"
+)
+
+// filterProfiles is used to filter profiles using a gitignore style exclusion file
+// if the file is not found the input list ius returned unaltered.
+func filterProfiles(profiles []*cover.Profile, ignoreFile string) ([]*cover.Profile, error) {
+	if _, err := os.Stat(ignoreFile); err != nil || len(profiles) == 0 {
+		return profiles, nil // no include file.
+	}
+
+	// ignore, err := createIgnore(ignoreFile)
+	ignore, err := gitignore.NewFromFile(ignoreFile)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read ignore file:%s", err)
+	}
+
+	filtered := make([]*cover.Profile, 0, len(profiles))
+	for _, p := range profiles {
+		m := ignore.Relative(p.FileName, false)
+		if m == nil {
+			filtered = append(filtered, p)
+		}
+	}
+
+	return filtered, nil
+}

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,63 @@
+package main
+
+import "testing"
+
+func TestFilterNoFile(t *testing.T) {
+	files := []string{"testdata/cover_1.out"}
+	profiles, err := loadProfilesForFiles(files)
+	if err != nil {
+		t.Fatal("fatal profile read", err)
+	}
+
+	if len(profiles) != 1 {
+		t.Fatal("profile len not 1", len(profiles))
+	}
+
+	ret, err := filterProfiles(profiles, "nofile")
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if len(ret) != len(profiles) {
+		t.Fatal("len wrong", len(profiles), len(ret))
+	}
+}
+
+func TestFilterIncludeAll(t *testing.T) {
+	files := []string{"testdata/cover_1.out"}
+	profiles, err := loadProfilesForFiles(files)
+	if err != nil {
+		t.Fatal("fatal profile read", err)
+	}
+
+	if len(profiles) != 1 {
+		t.Fatal("profile len not 1", len(profiles))
+	}
+
+	ret, err := filterProfiles(profiles, "testdata/filter")
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if len(ret) != len(profiles) {
+		t.Fatal("len wrong", len(profiles), len(ret))
+	}
+}
+
+func TestFilterIncludeNoAlt(t *testing.T) {
+	files := []string{"testdata/cover_multi.out"}
+	profiles, err := loadProfilesForFiles(files)
+	if err != nil {
+		t.Fatal("fatal profile read", err)
+	}
+
+	if len(profiles) != 3 {
+		t.Fatal("profile len not 3", len(profiles))
+	}
+
+	ret, err := filterProfiles(profiles, "testdata/filter")
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	if len(ret) != 1 {
+		t.Fatal("len wrong alt still in?", len(profiles), len(ret))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,9 @@ module github.com/nehemming/gocovdedup
 
 go 1.20
 
-require golang.org/x/tools v0.8.0
+require (
+	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817
+	golang.org/x/tools v0.8.0
+)
+
+require github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 h1:0nsrg//Dc7xC74H/TZ5sYR8uk4UQRNjsw8zejqH5a4Q=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817/go.mod h1:C/+sI4IFnEpCn6VQ3GIPEp+FrQnQw+YQP3+n+GdGq7o=
 golang.org/x/tools v0.8.0 h1:vSDcovVPld282ceKgDimkRSC8kpaH1dgyc9UMzlt84Y=
 golang.org/x/tools v0.8.0/go.mod h1:JxBZ99ISMI5ViVkT1tr6tdNmXeTrcpVSD3vZ1RsRdN4=

--- a/main.go
+++ b/main.go
@@ -215,5 +215,7 @@ func checkError(err error, w io.Writer, exit func(code int)) {
 func main() {
 	profiles, err := processArgs(os.Args, os.Stdin)
 	checkError(err, os.Stderr, os.Exit)
+	profiles, err = filterProfiles(profiles, ".coverignore")
+	checkError(err, os.Stderr, os.Exit)
 	printProfiles(deDuplicate(profiles), os.Stdout)
 }

--- a/testdata/cover_multi.out
+++ b/testdata/cover_multi.out
@@ -1,0 +1,13 @@
+mode: set
+github.com/repo/gocovdedup/main.go:17.76,19.22 2 0
+github.com/repo/gocovdedup/main.go:20.9,21.22 1 0
+github.com/repo/gocovdedup/main.go:22.10,25.35 3 0
+github.com/repo/gocovdedup/main.go:25.35,26.18 1 0
+github.com/repo/alternate/main.go:17.76,19.22 2 0
+github.com/repo/alternate/main.go:20.9,21.22 1 0
+github.com/repo/alternate/main.go:22.10,25.35 3 0
+github.com/repo/alternate/main.go:25.35,26.18 1 0
+github.com/proto/alternate/main.go:17.76,19.22 2 0
+github.com/proto/alternate/main.go:20.9,21.22 1 0
+github.com/proto/alternate/main.go:22.10,25.35 3 0
+github.com/proto/alternate/main.go:25.35,26.18 1 0

--- a/testdata/filter
+++ b/testdata/filter
@@ -1,0 +1,2 @@
+github.com/repo/alternate/*
+**/proto/**


### PR DESCRIPTION
Add support for cover ignore files

The exclude logic allows untestable folders such as auto generated code to be excluded from reports.